### PR TITLE
minor optimization for __scope_exists

### DIFF
--- a/scripts/iota_clock/iota_clock.gml
+++ b/scripts/iota_clock/iota_clock.gml
@@ -325,39 +325,66 @@ function iota_clock() constructor
     ///     0 = Deactivated instance
     ///     1 = Alive instance
     ///     2 = Alive struct
-    static __scope_exists = function(_scope)
-    {
-        //If this scope is a real number then it's an instance ID
-        if (is_real(_scope))
-        {
-            if (instance_exists(_scope)) return 1;
+    static __scope_exists = (
+		IOTA_CHECK_FOR_DEACTIVATION? 
+		
+		function(_scope) //does deactivation check
+	    {
+	        //If this scope is a real number then it's an instance ID
+	        if (is_real(_scope))
+	        {
+	            if (instance_exists(_scope)) return 1;
             
-            //Bonus check for deactivation
-            if (IOTA_CHECK_FOR_DEACTIVATION)
-            {
-                instance_activate_object(_scope);
-                if (instance_exists(_scope))
-                {
-                    instance_deactivate_object(_scope);
-                    return 0;
-                }
-            }
+	            //Bonus check for deactivation
+	            instance_activate_object(_scope);
+	            if (instance_exists(_scope))
+	            {
+	                instance_deactivate_object(_scope);
+	                return 0;
+	            }
             
-            return -1;
-        }
-        else
-        {
-            //If the scope wasn't a real number then presumably it's a weak reference to a struct
-            if (weak_ref_alive(_scope))
-            {
-                return 2;
-            }
-            else
-            {
-                return -2;
-            }
-        }
-    }
+	            return -1;
+	        }
+	        else
+	        {
+	            //If the scope wasn't a real number then presumably it's a weak reference to a struct
+	            if (weak_ref_alive(_scope))
+	            {
+	                return 2;
+	            }
+	            else
+	            {
+	                return -2;
+	            }
+	        }
+	    }
+		
+		:
+		
+		function(_scope)  //doesnt do deactivation check
+	    {
+	        //If this scope is a real number then it's an instance ID
+	        if (is_real(_scope))
+	        {
+	            if (instance_exists(_scope)) return 1;
+           
+	            return -1;
+	        }
+	        else
+	        {
+	            //If the scope wasn't a real number then presumably it's a weak reference to a struct
+	            if (weak_ref_alive(_scope))
+	            {
+	                return 2;
+	            }
+	            else
+	            {
+	                return -2;
+	            }
+	        }
+	    }
+		
+	);
     
     static __add_method_generic = function(_scope, _function, _method_type)
     {


### PR DESCRIPTION
removes a branch that checks for a static macro run time
when you only need to check it once